### PR TITLE
Fix fib.ts lint error

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Added return type to fibonacci function in fib.ts
Ran ```npm run lint``` to make sure lint no longer shows any errors for fib.ts
Ran ```npm run test``` to make sure all tests pass successfully 