### PR TITLE
Fix fibRoute.ts lint errors in a simpler manner

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,10 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
-import express from "express";
-const app = express();
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default app.get("/fib/:num", (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));
@@ -15,4 +14,4 @@ export default app.get("/fib/:num", (req, res) => {
   }
 
   res.send(result);
-});
+};


### PR DESCRIPTION
- Added Request and Response types from express to req and res parameters of the function
- Ran ```npm run lint``` to make sure lint no longer shows any errors for fibRoute.ts
- Ran ```npm run test``` to make sure all tests pass successfully
- Tested the application on ```localhost:3000/fib/n``` to make sure it was still working properly